### PR TITLE
feat(gtk driver): addReducer override for side-effects

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ function app (sink$) {
 
   sink$.addListener({
     next: ({ widget, options }) => {
+      widget.resize(600, 400)
+
       widget.once('show', () => {
         widget.setKeepAbove(true)
       })
@@ -35,21 +37,46 @@ function app (sink$) {
 
 function main ({ gtk, app }) {
   const gtkWindow$ = gtk.select('#window')
-  const gtkLabel$ = gtk.select('#label')
-  const gtkThree$ = gtk.select('#three')
 
-  const showAll$ = xs.merge(gtkWindow$, gtkLabel$, gtkThree$)
+  const showAll$ = xs.merge(
+    gtkWindow$,
+    gtk.select('#grid'),
+    gtk.select('#stack'),
+    gtk.select('#sidebar'),
+    gtk.select('#button_first'),
+    gtk.select('#button_second'),
+    gtk.select('#button_third')
+  )
     .endWhen(app.quit$)
 
   const timer$ = xs.periodic(1000)
     .map(function createTimerWindow (i) {
-      if (i % 3 === 0) {
-        return h('Window', '#window', { title: 'jsgtk', type: Gtk.WindowType.TOPLEVEL, windowPosition: Gtk.WindowPosition.CENTER }, [
-          h('Label', '#three', { label: `Time * 3 is ${i * 3}` })
-        ])
+      function stackAddReducer (parent, child) {
+        parent.attach(child, 1, 0, 1, 1)
+        child.setVexpand(true)
+        child.setHexpand(true)
       }
+
+      function sidebarAddReducer (parent, child, widgets) {
+        child.setStack(parent)
+        widgets['#grid'].widget.attach(child, 0, 0, 1, 1)
+      }
+
+      function makeButtonAddReducer (key) {
+        return function buttonAddReducer (parent, child) {
+          parent.addTitled(child, `#sidebar_${key}`, `Page ${key} ${i}`)
+        }
+      }
+
       return h('Window', '#window', { title: 'jsgtk', type: Gtk.WindowType.TOPLEVEL, windowPosition: Gtk.WindowPosition.CENTER }, [
-        h('Label', '#label', { label: `Time is ${i}` })
+        h('Grid', '#grid', {}, [
+          h('Stack', '#stack', { addReducer: stackAddReducer }, [
+            h('StackSidebar', '#sidebar', { addReducer: sidebarAddReducer }),
+            h('Button', '#button_first', { addReducer: makeButtonAddReducer('first'), label: `First ${i}` }),
+            h('Button', '#button_second', { addReducer: makeButtonAddReducer('second'), label: `Second ${i}` }),
+            h('Button', '#button_third', { addReducer: makeButtonAddReducer('third'), label: `Third ${i}` })
+          ])
+        ])
       ])
     })
     .endWhen(app.quit$)


### PR DESCRIPTION
More sophisticated demo and changes to handle side-effects.

Changes proposed:
- Fix `performPatch` reducer to pass parent instead of previous widget
- Add `addReducer` support to `gtkDriver` so certain creation intents can add their own reducer to manage how the widget is added to the parent
- Introduce stacked sidebar demo for show how more sophisticated applications can be created